### PR TITLE
Adds tests several options closes #6

### DIFF
--- a/t/has-output.t
+++ b/t/has-output.t
@@ -1,6 +1,12 @@
 use Log::Timeline;
 use Test;
 
-nok Log::Timeline.has-output, 'No output configured for Log::Timeline';
+with  %*ENV<LOG_TIMELINE_SERVER> {
+    ok Log::Timeline.has-output, 'Server output configured for Log::Timeline';
+} orwith  %*ENV<LOG_TIMELINE_JSON_LINES> {
+    ok Log::Timeline.has-output, 'Lines output configured for Log::Timeline';
+} else {
+    nok Log::Timeline.has-output, 'No output configured for Log::Timeline';
+}
 
 done-testing;


### PR DESCRIPTION
To avoid accidental error if by any chance the variable has been defined in a particular shell.

> Just to clarify, I had been running a program with that module somewhere else with a different Rakudo version. I changed to a shell, created the variable, tried to run, found that it was not installed for the version of Rakudo in *that* shell, tried to install... it failed.