### PR TITLE
Support CBOR Sequence file output

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,6 +7,7 @@
     "Jonathan Worthington <jnthn@jnthn.net>"
   ],
   "depends": [
+    "CBOR::Simple",
     "JSON::Fast"
   ],
   "build-depends": [],
@@ -15,6 +16,7 @@
     "Log::Timeline": "lib/Log/Timeline.pm6",
     "Log::Timeline::Model": "lib/Log/Timeline/Model.pm6",
     "Log::Timeline::Output": "lib/Log/Timeline/Output.pm6",
+    "Log::Timeline::Output::CBORSequence": "lib/Log/Timeline/Output/CBORSequence.pm6",
     "Log::Timeline::Output::JSONLines": "lib/Log/Timeline/Output/JSONLines.pm6",
     "Log::Timeline::Output::Socket": "lib/Log/Timeline/Output/Socket.pm6"
   },

--- a/lib/Log/Timeline.pm6
+++ b/lib/Log/Timeline.pm6
@@ -1,4 +1,5 @@
 use Log::Timeline::Model;
+use Log::Timeline::Output::CBORSequence;
 use Log::Timeline::Output::JSONLines;
 use Log::Timeline::Output::Socket;
 
@@ -24,5 +25,8 @@ with %*ENV<LOG_TIMELINE_SERVER> {
 }
 orwith %*ENV<LOG_TIMELINE_JSON_LINES> {
     PROCESS::<$LOG-TIMELINE-OUTPUT> = Log::Timeline::Output::JSONLines.new(path => .IO);
+}
+orwith %*ENV<LOG_TIMELINE_CBOR_SEQUENCE> {
+    PROCESS::<$LOG-TIMELINE-OUTPUT> = Log::Timeline::Output::CBORSequence.new(path => .IO);
 }
 END try .close with PROCESS::<$LOG-TIMELINE-OUTPUT>;

--- a/lib/Log/Timeline/Output/CBORSequence.pm6
+++ b/lib/Log/Timeline/Output/CBORSequence.pm6
@@ -1,0 +1,41 @@
+use Log::Timeline::Output;
+use CBOR::Simple;
+
+#| Outputs the log into a file as a CBOR Sequence (IETF RFC 8742),
+#| one encoded CBOR value per logged event.
+class Log::Timeline::Output::CBORSequence does Log::Timeline::Output {
+    #| The file to log into.
+    has IO::Path $.path is required;
+
+    #| The handle to write to.
+    has IO::Handle $!handle = open($!path, :w);
+
+    #| Logs an event.
+    method log-event($type, Int $parent-id, Instant $timestamp, %data --> Nil) {
+        $!handle.write: cbor-encode {
+            :m($type.module), :c($type.category), :n($type.name), :k(0),
+            :p($parent-id), :t($timestamp), :d(%data)
+        }
+    }
+
+    #| Logs the start of a task.
+    method log-start($type, Int $parent-id, Int $id, Instant $timestamp, %data --> Nil) {
+        $!handle.write: cbor-encode {
+            :m($type.module), :c($type.category), :n($type.name), :k(1),
+            :i($id), :p($parent-id), :t($timestamp), :d(%data)
+        }
+    }
+
+    #| Logs the end of a task.
+    method log-end($type, Int $id, Instant $timestamp --> Nil) {
+        $!handle.write: cbor-encode {
+            :m($type.module), :c($type.category), :n($type.name), :k(2),
+            :i($id), :t($timestamp)
+        }
+    }
+
+    #| Close the output file handle, flushing any events.
+    method close(--> Nil) {
+        $!handle.close;
+    }
+}

--- a/t/output-cbor-sequence.t
+++ b/t/output-cbor-sequence.t
@@ -1,0 +1,106 @@
+use Log::Timeline;
+use CBOR::Simple;
+use Test;
+
+my $test-file = $*TMPDIR.add('p6-log-timeline-cbor-test');
+END try unlink $test-file;
+PROCESS::<$LOG-TIMELINE-OUTPUT> = Log::Timeline::Output::CBORSequence.new(path => $test-file);
+
+class My::Test::EventA does Log::Timeline::Event['TestApp', 'Test Cat 1', 'EvA'] { }
+class My::Test::EventB does Log::Timeline::Event['TestApp', 'Test Cat 2', 'EvB'] { }
+class My::Test::TaskA does Log::Timeline::Task['TestApp', 'Test Cat 1', 'Task A'] { }
+class My::Test::TaskB does Log::Timeline::Task['TestApp', 'Test Cat 2', 'Task B'] { }
+
+ok Log::Timeline.has-output, 'We have output configured for Log::Timeline';
+
+lives-ok
+        {
+            My::Test::TaskA.log: propa => 'foo', {
+                My::Test::TaskB.log: {
+                    My::Test::EventA.log(propb => 'bar');
+                }
+                My::Test::EventB.log;
+            }
+        },
+        'Can log tasks with the file output logger';
+lives-ok { PROCESS::<$LOG-TIMELINE-OUTPUT>.close },
+        'Close method works';
+
+my $logged-sequence = $test-file.slurp(:bin);
+my $pos = 0;
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (1)';
+    is .<m>, 'TestApp', 'Correct module (1)';
+    is .<c>, 'Test Cat 1', 'Correct category (1)';
+    is .<n>, 'Task A', 'Correct name (1)';
+    is .<k>, 1, 'Correct kind (1)';
+    is .<i>, 1, 'Correct ID (1)';
+    is .<p>, 0, 'Correct parent (1)';
+    is-deeply .<d>, { propa => 'foo' }, 'Correct data (1)';
+    ok .<t>:exists, 'Has a timestamp (1)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (1)';
+}
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (2)';
+    is .<m>, 'TestApp', 'Correct module (2)';
+    is .<c>, 'Test Cat 2', 'Correct category (2)';
+    is .<n>, 'Task B', 'Correct name (2)';
+    is .<k>, 1, 'Correct kind (2)';
+    is .<i>, 2, 'Correct ID (2)';
+    is .<p>, 1, 'Correct parent (2)';
+    is-deeply .<d>, { }, 'Correct data (2)';
+    ok .<t>:exists, 'Has a timestamp (2)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (2)';
+}
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (3)';
+    is .<m>, 'TestApp', 'Correct module (3)';
+    is .<c>, 'Test Cat 1', 'Correct category (3)';
+    is .<n>, 'EvA', 'Correct name (3)';
+    is .<k>, 0, 'Correct kind (3)';
+    is .<p>, 2, 'Correct parent (3)';
+    is-deeply .<d>, { propb => 'bar' }, 'Correct data (3)';
+    ok .<t>:exists, 'Has a timestamp (3)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (3)';
+}
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (4)';
+    is .<m>, 'TestApp', 'Correct module (4)';
+    is .<c>, 'Test Cat 2', 'Correct category (4)';
+    is .<n>, 'Task B', 'Correct name (4)';
+    is .<k>, 2, 'Correct kind (4)';
+    is .<i>, 2, 'Correct ID (4)';
+    ok .<t>:exists, 'Has a timestamp (4)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (4)';
+}
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (5)';
+    is .<m>, 'TestApp', 'Correct module (5)';
+    is .<c>, 'Test Cat 2', 'Correct category (5)';
+    is .<n>, 'EvB', 'Correct name (5)';
+    is .<k>, 0, 'Correct kind (5)';
+    is .<p>, 1, 'Correct parent (5)';
+    is-deeply .<d>, { }, 'Correct data (5)';
+    ok .<t>:exists, 'Has a timestamp (5)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (5)';
+}
+
+given cbor-decode($logged-sequence, $pos) {
+    isa-ok $_, Hash, 'Entry deserialized to a Hash (6)';
+    is .<m>, 'TestApp', 'Correct module (6)';
+    is .<c>, 'Test Cat 1', 'Correct category (6)';
+    is .<n>, 'Task A', 'Correct name (6)';
+    is .<k>, 2, 'Correct kind (6)';
+    is .<i>, 1, 'Correct ID (6)';
+    ok .<t>:exists, 'Has a timestamp (6)';
+    isa-ok .<t>, Instant, 'Timestamp is an instant (6)';
+}
+
+is $pos, $logged-sequence.bytes, 'Log file has expected number of CBOR elements';
+
+done-testing;


### PR DESCRIPTION
* Adds dependency on CBOR::Simple
* Adds Log::Timeline::Output::CBORSequence
* Adds tests, copied and tweaked from matching JSONLines tests
* Triggers CBOR Sequence logging with a filename in the
  `LOG_TIMELINE_CBOR_SEQUENCE` env var (at lowest priority of output types)

Notes:

* Timestamps round trip as real Instants, not Rats.
* In my local tests, CBORSequence output was about 1/3 smaller than (2/3 the size of) JSONLines output.
* Raw CBOR data can be visualized using `cbor-diagnostic()`, which outputs the RFC standard debugging diagnostic format.
* It is the presence of the `$pos` rw argument to `cbor-decode()` that puts it in sequence decode mode (decoding one CBOR value and then updating `$pos`, allowing a cycling buffer event-at-a-time idiom).